### PR TITLE
fix: Off-by-one error in HashElems for odd-length inputs

### DIFF
--- a/types/util.go
+++ b/types/util.go
@@ -22,7 +22,7 @@ func HashElems(fst, snd *big.Int, elems ...*big.Int) (*Hash, error) {
 	tmp := make([]*big.Int, (l+1)/2)
 	for i := range tmp {
 		if (i+1)*2 > l {
-			tmp[i] = elems[i*2+1]
+			tmp[i] = elems[i*2]
 		} else {
 			h, err := hashScheme(elems[i*2 : (i+1)*2])
 			if err != nil {


### PR DESCRIPTION
**Explanation**

- The length of `tmp` is `(l + 1) / 2` so in the last iteration `i` is `(l + 1) / 2 - 1`.
- If `l` is even, in the last iteration `(i+1)*2` will evaluate to `l` and we will enter the `else` branch.
- No issue in this case.
- If `l` is odd, in the last iteration `(i+1)*2` will evaluate to `l + 1` and we will enter the `if` branch.
- Inside the `if` branch, `i*2+1` will evaluate to `l`.
- We will try to reference `elems[l]` which will lead to `index out of range`.

**Example error**

```
--- FAIL: TestMerkleTree_UpdateAccount (0.00s)
panic: runtime error: index out of range [3] with length 3 [recovered]
	panic: runtime error: index out of range [3] with length 3

goroutine 50 [running]:
testing.tRunner.func1.2({0x100b1d840, 0x140000162b8})
	/opt/homebrew/Cellar/go@1.18/1.18.10/libexec/src/testing/testing.go:1389 +0x1c8
testing.tRunner.func1()
	/opt/homebrew/Cellar/go@1.18/1.18.10/libexec/src/testing/testing.go:1392 +0x384
panic({0x100b1d840, 0x140000162b8})
	/opt/homebrew/Cellar/go@1.18/1.18.10/libexec/src/runtime/panic.go:838 +0x204
github.com/scroll-tech/zktrie/types.HashElems(0x1400018d840, 0x1400018d860, {0x140001a06a0, 0x3, 0x3})
	/Users/peter/go/pkg/mod/github.com/scroll-tech/zktrie@v0.4.2/types/util.go:25 +0x2b8
github.com/scroll-tech/zktrie/types.PreHandlingElems(0x8, {0x140001d0000, 0x5, 0x10085fd34?})
	/Users/peter/go/pkg/mod/github.com/scroll-tech/zktrie@v0.4.2/types/util.go:61 +0xa8
github.com/scroll-tech/zktrie/trie.(*Node).Key(0x1400012bc10)
	/Users/peter/go/pkg/mod/github.com/scroll-tech/zktrie@v0.4.2/trie/zk_trie_node.go:134 +0xc0
github.com/scroll-tech/zktrie/trie.(*ZkTrieImpl).TryUpdate(0x140001a0660, 0x1400018fe20, 0x8, {0x140001d0000, 0x5, 0x5})
	/Users/peter/go/pkg/mod/github.com/scroll-tech/zktrie@v0.4.2/trie/zk_trie_impl.go:107 +0x170
github.com/scroll-tech/go-ethereum/trie.(*zkTrieImplTestWrapper).TryUpdateAccount(0x14000010050, {0x1400005bda8, 0x14, 0x1008f5e9e?}, 0x10096d85a?)
	/Users/peter/l2geth/trie/zk_trie_impl_test.go:92 +0xe4
github.com/scroll-tech/go-ethereum/trie.TestMerkleTree_UpdateAccount(0x0?)
	/Users/peter/l2geth/trie/zk_trie_impl_test.go:233 +0x1f0
testing.tRunner(0x14000513040, 0x100b3ac20)
	/opt/homebrew/Cellar/go@1.18/1.18.10/libexec/src/testing/testing.go:1439 +0x110
created by testing.(*T).Run
	/opt/homebrew/Cellar/go@1.18/1.18.10/libexec/src/testing/testing.go:1486 +0x300
FAIL	github.com/scroll-tech/go-ethereum/trie	0.802s
FAIL
```