### PR TITLE
fix: TOB-ZKTRIE-16 Safe-Rust ZkMemoryDb interface is not thread-safe

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -163,10 +163,14 @@ func InitDbByNode(pDb C.uintptr_t, data *C.uchar, sz C.int) *C.char {
 	if err != nil {
 		return C.CString(err.Error())
 	}
-	db.Init(hash[:], n.CanonicalValue())
+
+	// use the thread-safe variant
+	err = db.Put(hash[:], n.CanonicalValue())
+	if err != nil {
+		return C.CString(err.Error())
+	}
 
 	return nil
-
 }
 
 // the input root must be 32bytes (or more, but only first 32bytes would be recognized)


### PR DESCRIPTION
Use the thread-safe Put method instead of the unlocked Init.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205044772140411