### PR TITLE
Rework trie to do lazy commitment calculation

### DIFF
--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -126,12 +126,26 @@ func (t *ZkTrie) TryDelete(key []byte) error {
 // Hash returns the root hash of SecureBinaryTrie. It does not write to the
 // database and can be used even if the trie doesn't have one.
 func (t *ZkTrie) Hash() []byte {
-	return t.tree.rootHash.Bytes()
+	root, err := t.tree.Root()
+	if err != nil {
+		panic("root failed in trie.Hash")
+	}
+	return root.Bytes()
+}
+
+// Commit flushes the trie to database
+func (t *ZkTrie) Commit() error {
+	return t.tree.Commit()
 }
 
 // Copy returns a copy of SecureBinaryTrie.
 func (t *ZkTrie) Copy() *ZkTrie {
-	cpy, err := NewZkTrieImplWithRoot(t.tree.db, t.tree.rootHash, t.tree.maxLevels)
+	err := t.tree.Commit()
+	if err != nil {
+		panic("commit failed in clone trie")
+	}
+
+	cpy, err := NewZkTrieImplWithRoot(t.tree.db, t.tree.rootKey, t.tree.maxLevels)
 	if err != nil {
 		panic("clone trie failed")
 	}

--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -140,17 +140,8 @@ func (t *ZkTrie) Commit() error {
 
 // Copy returns a copy of SecureBinaryTrie.
 func (t *ZkTrie) Copy() *ZkTrie {
-	err := t.tree.Commit()
-	if err != nil {
-		panic("commit failed in clone trie")
-	}
-
-	cpy, err := NewZkTrieImplWithRoot(t.tree.db, t.tree.rootKey, t.tree.maxLevels)
-	if err != nil {
-		panic("clone trie failed")
-	}
 	return &ZkTrie{
-		tree: cpy,
+		tree: t.tree.Copy(),
 	}
 }
 

--- a/trie/zk_trie_impl.go
+++ b/trie/zk_trie_impl.go
@@ -784,3 +784,19 @@ node [fontname=Monospace,fontsize=10,shape=box]
 	}
 	return err
 }
+
+// Copy creates a new independent zkTrie from the given trie
+func (mt *ZkTrieImpl) Copy() *ZkTrieImpl {
+	// Deep copy in-memory dirty nodes
+	newDirtyStorage := make(map[zkt.Hash]*Node, len(mt.dirtyStorage))
+	for key, dirtyNode := range mt.dirtyStorage {
+		newDirtyStorage[key] = dirtyNode.Copy()
+	}
+
+	newTrie := *mt
+	newTrie.dirtyIndex = new(big.Int).Set(mt.dirtyIndex)
+	newTrie.dirtyStorage = newDirtyStorage
+	newRootKey := *mt.rootKey
+	newTrie.rootKey = &newRootKey
+	return &newTrie
+}

--- a/trie/zk_trie_impl_test.go
+++ b/trie/zk_trie_impl_test.go
@@ -96,6 +96,7 @@ func TestMerkleTree_Init(t *testing.T) {
 		assert.NoError(t, err)
 		mt1Root, err = mt1.Root()
 		assert.NoError(t, err)
+		assert.Equal(t, "0539c6b1cac741eb1e98b2c271733d1e6f0fad557228f6b039d894b0a627c8d9", mt1Root.Hex())
 		assert.NoError(t, mt1.Commit())
 
 		mt2, err := NewZkTrieImplWithRoot(db, mt1Root, maxLevels)

--- a/trie/zk_trie_node.go
+++ b/trie/zk_trie_node.go
@@ -331,3 +331,12 @@ func (n *Node) String() string {
 		return "Invalid Node"
 	}
 }
+
+// Copy creates a new Node instance from the given node
+func (n *Node) Copy() *Node {
+	newNode, err := NewNodeFromBytes(n.Value())
+	if err != nil {
+		panic("failed to copy trie node")
+	}
+	return newNode
+}

--- a/trie/zk_trie_proof.go
+++ b/trie/zk_trie_proof.go
@@ -33,7 +33,7 @@ func (mt *ZkTrieImpl) prove(kHash *zkt.Hash, fromLevel uint, writeNode func(*Nod
 	path := getPath(mt.maxLevels, kHash[:])
 	var nodes []*Node
 	var lastN *Node
-	tn := mt.rootHash
+	tn := mt.rootKey
 	for i := 0; i < mt.maxLevels; i++ {
 		n, err := mt.GetNode(tn)
 		if err != nil {

--- a/trie/zk_trie_proof.go
+++ b/trie/zk_trie_proof.go
@@ -66,7 +66,9 @@ func (mt *ZkTrieImpl) prove(kHash *zkt.Hash, fromLevel uint, writeNode func(*Nod
 			return ErrInvalidNodeFound
 		}
 
-		nodes = append(nodes, n)
+		nCopy := n.Copy()
+		nCopy.nodeHash = tn
+		nodes = append(nodes, nCopy)
 		if finished {
 			break
 		}

--- a/trie/zk_trie_test.go
+++ b/trie/zk_trie_test.go
@@ -34,7 +34,7 @@ func TestNewZkTrie(t *testing.T) {
 	zkTrie, err := NewZkTrie(root, db)
 	assert.NoError(t, err)
 	assert.Equal(t, zkt.HashZero.Bytes(), zkTrie.Hash())
-	assert.Equal(t, zkt.HashZero.Bytes(), zkTrie.Tree().rootHash.Bytes())
+	assert.Equal(t, zkt.HashZero.Bytes(), zkTrie.Tree().rootKey.Bytes())
 
 	root = zkt.Byte32{1}
 	zkTrie, err = NewZkTrie(root, db)


### PR DESCRIPTION
Looks to be syncing fine to Scroll mainnet.

According to my very simple benchmark setup, historical sync speed is improved from ~12mgas/s to ~26mgas/s on my machine. 