### PR TITLE
feat: make DB types shareable accross threads

### DIFF
--- a/src/go_lib.rs
+++ b/src/go_lib.rs
@@ -219,7 +219,7 @@ impl ZkMemoryDb {
     }
 
     // the zktrie can be created only if the corresponding root node has been added
-    pub fn new_trie(self: &Rc<Self>, root: &Hash) -> Option<ZkTrie> {
+    pub fn new_trie(self: &Arc<Self>, root: &Hash) -> Option<ZkTrie> {
         let ret = unsafe { NewZkTrie(root.as_ptr(), self.db) };
 
         if ret.is_null() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn trie_works() {
-        use std::rc::Rc;
+        use std::sync::Arc;
 
         init_hash_scheme_simple(poseidon_hash_scheme);
         let mut db = ZkMemoryDb::new();
@@ -173,7 +173,7 @@ mod tests {
             let buf = hex::decode(bts.get(2..).unwrap()).unwrap();
             db.add_node_data(&buf).unwrap();
         }
-        let mut db = Rc::new(db);
+        let mut db = Arc::new(db);
 
         let root = hex::decode("194cfd0c3cce58ac79c5bab34b149927e0cd9280c6d61870bfb621d45533ddbc")
             .unwrap();
@@ -261,7 +261,7 @@ mod tests {
         trie.commit().unwrap();
 
         let trie_db = trie.updated_db();
-        Rc::get_mut(&mut db).expect("no reference").update(trie_db);
+        Arc::get_mut(&mut db).expect("no reference").update(trie_db);
         let trie = db.new_ref_trie(&root).unwrap();
 
         let proof = trie.prove(&acc_buf).unwrap();

--- a/src/rs_lib.rs
+++ b/src/rs_lib.rs
@@ -1,5 +1,5 @@
 use super::constants::*;
-use std::{collections::HashMap, rc::Rc};
+use std::{collections::HashMap, sync::Arc};
 use zktrie_rust::{
     db::ZktrieDatabase,
     types::{Hashable, TrieHashScheme},
@@ -128,7 +128,7 @@ pub struct ZkMemoryDb {
 }
 
 #[derive(Clone)]
-pub struct SharedMemoryDb(Rc<ZkMemoryDb>);
+pub struct SharedMemoryDb(Arc<ZkMemoryDb>);
 
 impl db::ZktrieDatabase for SharedMemoryDb {
     fn put(&mut self, _: Vec<u8>, _: Vec<u8>) -> Result<(), raw::ImplError> {
@@ -146,7 +146,7 @@ impl trie::KeyCache<HashImpl> for SharedMemoryDb {
 }
 
 #[derive(Clone)]
-pub struct UpdateDb(db::SimpleDb, Rc<ZkMemoryDb>);
+pub struct UpdateDb(db::SimpleDb, Arc<ZkMemoryDb>);
 
 impl UpdateDb {
     pub fn updated_db(self) -> db::SimpleDb {
@@ -228,7 +228,7 @@ impl ZkMemoryDb {
     }
 
     /// the zktrie can be created only if the corresponding root node has been added
-    pub fn new_trie(self: &Rc<Self>, root: &Hash) -> Option<ZkTrie<UpdateDb>> {
+    pub fn new_trie(self: &Arc<Self>, root: &Hash) -> Option<ZkTrie<UpdateDb>> {
         HashImpl::from_bytes(root.as_slice())
             .ok()
             .and_then(|h| ZktrieRs::new_zktrie(h, UpdateDb(Default::default(), self.clone())).ok())
@@ -236,7 +236,7 @@ impl ZkMemoryDb {
     }
 
     /// the zktrie can be created only if the corresponding root node has been added
-    pub fn new_ref_trie(self: &Rc<Self>, root: &Hash) -> Option<ZkTrie<SharedMemoryDb>> {
+    pub fn new_ref_trie(self: &Arc<Self>, root: &Hash) -> Option<ZkTrie<SharedMemoryDb>> {
         HashImpl::from_bytes(root.as_slice())
             .ok()
             .and_then(|h| ZktrieRs::new_zktrie(h, SharedMemoryDb(self.clone())).ok())


### PR DESCRIPTION
will cherry-pick to `v0.9` branch once merged.