### PR TITLE
Grammar and Style Improvements

### DIFF
--- a/docs/zktrie.md
+++ b/docs/zktrie.md
@@ -10,7 +10,7 @@
 In essence, zkTrie is a sparse binary Merkle Patricia Trie, depicted in the above figure.
 Before diving into the Sparse Binary Merkle Patricia Trie, let's briefly touch on Merkle Trees and Patricia Tries.
 * **Merkle Tree**: A Merkle Tree is a tree where each leaf node represents a hash of a data block, and each non-leaf node represents the hash of its child nodes.
-* **Patricia Trie**: A Patricia Trie is a type of radix tree or compressed trie used to store key-value pairs efficiently. It encodes the nodes with same prefix of the key to share the common path, where the path is determined by the value of the node key.
+* **Patricia Trie**: A Patricia Trie is a type of radix tree or compressed trie used to store key-value pairs efficiently. It encodes the nodes with the same prefix of the key to share the common path, where the path is determined by the value of the node key.
 
 As illustrated in the Figure 1, there are three types of nodes in the zkTrie.
 - Parent Node (type: 0): Given the zkTrie is a binary tree, a parent node has two children.
@@ -138,7 +138,7 @@ valLo = storageKey[16:32]
 nodeKey = h(valHi, valLo)
 ```
 
-The storage value is a `u256` value. The `flag` for the storage value is 1, showed below.
+The storage value is a `u256` value. The `flag` for the storage value is 1, shown below.
 
 ```
 +--------------+

--- a/types/README.md
+++ b/types/README.md
@@ -2,7 +2,7 @@
 
 ## Data Format in stateDb
 
-All data node being stored via stateDb are encoded by following syntax:
+All data nodes being stored via stateDb are encoded by following syntax:
 
 ``` EBNF
     node             =  magic string | node data ;
@@ -90,7 +90,7 @@ Each account data is saved in one leaf node of account zktrie as 4 `value field`
 3. CodeHash as `compressed field` (byte32)
 4. Storage root as `field`
 
-The key for an account data is calculated from the 20-bit account address as following:
+The key for an account data is calculated from the 20-bit account address as follows:
 
 ```
 
@@ -106,7 +106,7 @@ key = poseidon(<first 16 byte of 32-byte-zero-end-padding-addr as field>, <last 
 
 > 0x017f9d3bbc51d12566ecc6049ca6bf76e32828c22b197405f63a833b566fe7da0a040400000000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000029b74e075daad9f17eb39cd893c2dd32f52ecd99084d63964842defd00ebcbe208a2f471d50e56ac5000ab9e82f871e36b5a636b19bd02f70aa666a3bd03142f00
 
-Can be decompose to:
+Can be decomposed to:
 
 + `0x01`: node type prefix for leaf node
 + `7f9d3bbc51d12566ecc6049ca6bf76e32828c22b197405f63a833b566fe7da0a`: node key as field


### PR DESCRIPTION

## Changes

### In `docs/zktrie.md`:
1. "nodes with same prefix" → "nodes with the same prefix"
   - Added missing article "the" for grammatical correctness
2. "showed below" → "shown below"
   - Corrected to proper past participle form

### In `types/README.md`:
1. "data node being stored" → "data nodes being stored"
   - Fixed singular/plural agreement
2. "Can be decompose" → "Can be decomposed"
   - Corrected to proper past participle form
3. "as following" → "as follows"
   - Fixed to proper idiomatic expression

## Rationale

These changes improve the documentation by:
- Ensuring proper grammar and consistent style
- Using correct verb forms and tenses
- Adding missing articles where grammatically required
- Making technical documentation more professional and easier to read

The modifications maintain the technical accuracy while enhancing readability and adherence to English language conventions.

## Files Modified
- docs/zktrie.md
- types/README.md