### PR TITLE
Typos fix

### DIFF
--- a/trie/zk_trie_node.go
+++ b/trie/zk_trie_node.go
@@ -99,7 +99,7 @@ type Node struct {
 	ChildR *zkt.Hash
 	// NodeKey is the node's key stored in a leaf node.
 	NodeKey *zkt.Hash
-	// ValuePreimage can store at most 256 byte32 as fields (represnted by BIG-ENDIAN integer)
+	// ValuePreimage can store at most 256 byte32 as fields (represented by BIG-ENDIAN integer)
 	// and the first 24 can be compressed (each bytes32 consider as 2 fields), in hashing the compressed
 	// elemments would be calculated first
 	ValuePreimage []zkt.Byte32

--- a/types/util.go
+++ b/types/util.go
@@ -5,7 +5,7 @@ import (
 )
 
 // HashElemsWithDomain performs a recursive poseidon hash over the array of ElemBytes, each hash
-// reduce 2 fieds into one, with a specified domain field which would be used in
+// reduce 2 fields, fiends into one, with a specified domain field which would be used in
 // every recursiving call
 func HashElemsWithDomain(domain, fst, snd *big.Int, elems ...*big.Int) (*Hash, error) {
 


### PR DESCRIPTION
### Changes

1. **File:** `/types/util.go`
    - Fixed `fieds` to `fields, fiends` (Line 8)
1. **File:** `/trie/zk_trie_node.go`
    - Fixed `represnted` to `represented` (Line 102)

### Purpose

- Improved documentation accuracy by fixing typographical errors.
- Ensured better readability and consistency.