### PR TITLE
Fixed typos

### DIFF
--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -145,7 +145,7 @@ func (t *ZkTrie) Copy() *ZkTrie {
 	}
 }
 
-// Prove is a simlified calling of ProveWithDeletion
+// Prove is a simplified calling of ProveWithDeletion
 func (t *ZkTrie) Prove(key []byte, fromLevel uint, writeNode func(*Node) error) error {
 	return t.ProveWithDeletion(key, fromLevel, writeNode, nil)
 }

--- a/types/util.go
+++ b/types/util.go
@@ -43,7 +43,7 @@ func HashElems(fst, snd *big.Int, elems ...*big.Int) (*Hash, error) {
 		fst, snd, elems...)
 }
 
-// HandlingElemsAndByte32 hash an arry mixed with field and byte32 elements, turn each byte32 into
+// HandlingElemsAndByte32 hash an array, carry mixed with field and byte32 elements, turn each byte32 into
 // field elements first then calculate the hash with HashElems
 func HandlingElemsAndByte32(flagArray uint32, elems []Byte32) (*Hash, error) {
 

--- a/types/util.go
+++ b/types/util.go
@@ -43,7 +43,7 @@ func HashElems(fst, snd *big.Int, elems ...*big.Int) (*Hash, error) {
 		fst, snd, elems...)
 }
 
-// HandlingElemsAndByte32 hash an array, carry mixed with field and byte32 elements, turn each byte32 into
+// HandlingElemsAndByte32 hash an array, carray, carry mixed with field and byte32 elements, turn each byte32 into
 // field elements first then calculate the hash with HashElems
 func HandlingElemsAndByte32(flagArray uint32, elems []Byte32) (*Hash, error) {
 


### PR DESCRIPTION
### Changes

1. **File:** `/types/util.go`
    - Fixed `arry` to `array, carry` (Line 46)
1. **File:** `/trie/zk_trie.go`
    - Fixed `simlified` to `simplified` (Line 148)

### Purpose

- Enhanced the clarity and professionalism of the documentation.
- Fixed minor grammatical issues for better understanding.