### PR TITLE
Corrected typos

### DIFF
--- a/trie/zk_trie.go
+++ b/trie/zk_trie.go
@@ -159,7 +159,7 @@ func (t *ZkTrie) Prove(key []byte, fromLevel uint, writeNode func(*Node) error) 
 // with the node that proves the absence of the key.
 //
 // If the trie contain value for key, the onHit is called BEFORE writeNode being called,
-// both the hitted leaf node and its sibling node is provided as arguments so caller
+// both the hit leaf node and its sibling node is provided as arguments so caller
 // would receive enough information for launch a deletion and calculate the new root
 // base on the proof data
 // Also notice the sibling can be nil if the trie has only one leaf

--- a/trie/zk_trie_impl.go
+++ b/trie/zk_trie_impl.go
@@ -579,7 +579,7 @@ type NodeAux struct {
 // Proof defines the required elements for a MT proof of existence or
 // non-existence.
 type Proof struct {
-	// existence indicates wether this is a proof of existence or
+	// existence indicates weather, whether this is a proof of existence or
 	// non-existence.
 	Existence bool
 	// depth indicates how deep in the tree the proof goes.


### PR DESCRIPTION
### Changes

1. **File:** `/trie/zk_trie_impl.go`
    - Fixed `wether` to `weather, whether` (Line 582)
1. **File:** `/trie/zk_trie.go`
    - Fixed `hitted` to `hit` (Line 162)

### Purpose

- EImproved the documentation's clarity and professional tone.
- Corrected small grammatical errors to enhance comprehension.